### PR TITLE
Addresses #2: adds variables support

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -91,8 +91,14 @@ class OctokitController {
 		let variables: Record<string, unknown> | undefined;
 		const match = contents.match(variablesRegex);
 		if (match) {
-			const variablesString = match[1];
-			variables = JSON.parse(variablesString);
+			try {
+				variables = JSON.parse(match[1]);
+			} catch (e) {
+				replaceOutput(task, `Unable to parse 'variables': ${String(e)}`);
+				task.end(false, Date.now());
+				return;
+			}
+
 			code = contents.replace(variablesRegex, '').trim();
 		} else {
 			code = contents.trim();


### PR DESCRIPTION
Adds support for `variables { }` expression to be added into each cell to provide them to the query

Example:
```graphql
query ($owner: String!,	$repo: String!) { 
  repository(owner: $owner, name: $repo) {
    name
  }
}

variables {
  "owner": "eamodio",
  "repo": "vscode-gitlens"
}
```